### PR TITLE
add-bun-tsconfig

### DIFF
--- a/docs/exports.md
+++ b/docs/exports.md
@@ -38,6 +38,16 @@ In your package that uses the `@dragee-io/type` package, you must specify in the
 }
 ```
 
+**OR**
+
+by extending the tsconfig.json file of the package:
+
+```json
+{
+    "extends": "@dragee-io/type/tsconfig.bun",
+}
+```
+
 This is required to inform typescript that it must resolve the typescript files in the package under a specific condition.
 
 ---

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
         "./test-utils": {
             "bun": "./test-utils/index.ts",
             "import": "./dist/test-utils/index.js"
-        }
+        },
+        "./tsconfig.bun": "./tsconfig.bun.json"
     },
     "trustedDependencies": ["@biomejs/biome"],
     "devDependencies": {

--- a/tsconfig.bun.json
+++ b/tsconfig.bun.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "customConditions": ["bun"]
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,6 @@
         "forceConsistentCasingInFileNames": true,
 
         /* Multi-package */
-        "composite": true,
         "declarationMap": true
     }
 }


### PR DESCRIPTION
Add Bun tsconfig

This pull request adds a `tsconfig.bun` file to the project, which provides an alternative TypeScript configuration for Bun extensions. The new configuration file can be extended by other packages that require a Bun-specific TypeScript setup.

Additionally, the PR includes documentation explaining the purpose and usage of the `tsconfig.bun` file.