### PR TITLE
fix: compute rulesCount from total results instead of rule definiation

### DIFF
--- a/src/asserter/index.ts
+++ b/src/asserter/index.ts
@@ -1,31 +1,31 @@
-import { Glob } from 'bun';
-import { type Dragee, generateId } from '../common';
-import { basename } from 'node:path';
+import { Glob } from "bun";
+import { type Dragee, generateId } from "../common";
+import { basename } from "node:path";
 
 export type ReportStats = {
-    rulesCount: number;
-    passCount: number;
-    errorsCount: number;
+  rulesCount: number;
+  passCount: number;
+  errorsCount: number;
 };
 export type RuleError = {
-    ruleId?: string;
-    message: string;
-    drageeName: string;
+  ruleId?: string;
+  message: string;
+  drageeName: string;
 };
 export type Report = {
-    pass: boolean;
-    namespace: string;
-    errors: RuleError[];
-    stats: ReportStats;
+  pass: boolean;
+  namespace: string;
+  errors: RuleError[];
+  stats: ReportStats;
 };
 export type SuccessfulRuleResult = {
-    ruleId?: string;
-    pass: true;
+  ruleId?: string;
+  pass: true;
 };
 export type FailedRuleResult = {
-    ruleId?: string;
-    pass: false;
-    error: RuleError;
+  ruleId?: string;
+  pass: false;
+  error: RuleError;
 };
 export type RuleResult = SuccessfulRuleResult | FailedRuleResult;
 
@@ -36,11 +36,11 @@ export type Failed = (dragee: Dragee, message: string) => FailedRuleResult;
 export type AssertHandler = (asserter: Asserter, dragees: Dragee[]) => Report;
 
 export const successful: Successful = () => {
-    return { pass: true };
+  return { pass: true };
 };
 
 export const failed: Failed = (dragee: Dragee, message: string) => {
-    return { pass: false, error: { drageeName: dragee.name, message } };
+  return { pass: false, error: { drageeName: dragee.name, message } };
 };
 
 /**
@@ -50,15 +50,17 @@ export const failed: Failed = (dragee: Dragee, message: string) => {
  * @returns
  */
 export const directDependencies = (root: Dragee, allDragees: Dragee[]) => {
-    if (!root.depends_on) {
-        return { root, dependencies: [] };
-    }
+  if (!root.depends_on) {
+    return { root, dependencies: [] };
+  }
 
-    const dependencies = Object.keys(root.depends_on)
-        .map(dependency => allDragees.find(dragee => dragee.name === dependency))
-        .filter((dragee): dragee is Dragee => dragee !== undefined);
+  const dependencies = Object.keys(root.depends_on)
+    .map((dependency) =>
+      allDragees.find((dragee) => dragee.name === dependency),
+    )
+    .filter((dragee): dragee is Dragee => dragee !== undefined);
 
-    return { root, dependencies };
+  return { root, dependencies };
 };
 
 /**
@@ -67,11 +69,11 @@ export const directDependencies = (root: Dragee, allDragees: Dragee[]) => {
  * @returns an iterator of the files matching the rule pattern
  */
 function scanRuleFiles(dir: string) {
-    return new Glob('*.rule.ts').scanSync({
-        cwd: dir,
-        absolute: true,
-        onlyFiles: true
-    });
+  return new Glob("*.rule.ts").scanSync({
+    cwd: dir,
+    absolute: true,
+    onlyFiles: true,
+  });
 }
 
 /**
@@ -82,32 +84,36 @@ function scanRuleFiles(dir: string) {
  * @returns rules found in dir
  */
 export const findRules = (namespace: string, dir: string): Rule[] => {
-    const files = scanRuleFiles(dir);
+  const files = scanRuleFiles(dir);
 
-    return Array.from(files)
-        .map(file => require(file).default as DeclaredRule)
-        .map(rule => declaredRuleToRule(namespace, rule));
+  return Array.from(files)
+    .map((file) => require(file).default as DeclaredRule)
+    .map((rule) => declaredRuleToRule(namespace, rule));
 };
 
-export function findRule(namespace: string, dir: string, ruleName: string): Rule | undefined {
-    const files = scanRuleFiles(dir);
+export function findRule(
+  namespace: string,
+  dir: string,
+  ruleName: string,
+): Rule | undefined {
+  const files = scanRuleFiles(dir);
 
-    const file = Array.from(files).find((file) =>
-      basename(file) === `${ruleName}.rule.ts`
-    );
+  const file = Array.from(files).find(
+    (file) => basename(file) === `${ruleName}.rule.ts`,
+  );
 
-    if (!file) {
-        return undefined;
-    }
+  if (!file) {
+    return undefined;
+  }
 
-    const rule = require(file).default;
-    return declaredRuleToRule(namespace, rule);
+  const rule = require(file).default;
+  return declaredRuleToRule(namespace, rule);
 }
 
 export type Asserter = {
-    readonly namespace: string;
-    readonly rules: Rule[];
-    rule: (file: string) => Rule | undefined;
+  readonly namespace: string;
+  readonly rules: Rule[];
+  rule: (file: string) => Rule | undefined;
 };
 
 /**
@@ -116,35 +122,38 @@ export type Asserter = {
  * @param dragees Dragees to test against the asserter rules
  * @returns Report of dragees testing
  */
-export const asserterHandler: AssertHandler = (asserter: Asserter, dragees: Dragee[]): Report => {
-    const rulesResults = asserter.rules.flatMap(rule =>
-        rule.handler(dragees).map(result => {
-            result.ruleId = rule.id;
-            return result;
-        })
-    );
+export const asserterHandler: AssertHandler = (
+  asserter: Asserter,
+  dragees: Dragee[],
+): Report => {
+  const rulesResults = asserter.rules.flatMap((rule) =>
+    rule.handler(dragees).map((result) => {
+      result.ruleId = rule.id;
+      return result;
+    }),
+  );
 
-    const rulesResultsErrors = rulesResults
-        .filter((result): result is FailedRuleResult => !result.pass)
-        .map(result => {
-            result.error.ruleId = result.ruleId;
-            return result.error;
-        });
+  const rulesResultsErrors = rulesResults
+    .filter((result): result is FailedRuleResult => !result.pass)
+    .map((result) => {
+      result.error.ruleId = result.ruleId;
+      return result.error;
+    });
 
-    const rulesResultsPassed = rulesResults.filter(
-        (result): result is SuccessfulRuleResult => result.pass
-    );
+  const rulesResultsPassed = rulesResults.filter(
+    (result): result is SuccessfulRuleResult => result.pass,
+  );
 
-    return {
-        pass: rulesResultsErrors.length === 0,
-        namespace: asserter.namespace,
-        errors: rulesResultsErrors,
-        stats: {
-            errorsCount: rulesResultsErrors.length,
-            passCount: rulesResultsPassed.length,
-            rulesCount: asserter.rules.length
-        }
-    };
+  return {
+    pass: rulesResultsErrors.length === 0,
+    namespace: asserter.namespace,
+    errors: rulesResultsErrors,
+    stats: {
+      errorsCount: rulesResultsErrors.length,
+      passCount: rulesResultsPassed.length,
+      rulesCount: rulesResults.length,
+    },
+  };
 };
 
 /**
@@ -153,69 +162,73 @@ export const asserterHandler: AssertHandler = (asserter: Asserter, dragees: Drag
  * @param dragees Dragees to test against the asserter rules
  * @returns Report of dragees testing
  */
-export function generateReportForRule(asserter: Asserter, dragees: Dragee[], file: string): Report {
-    const rule = asserter.rule(file);
+export function generateReportForRule(
+  asserter: Asserter,
+  dragees: Dragee[],
+  file: string,
+): Report {
+  const rule = asserter.rule(file);
 
-    if (!rule) {
-        return {
-            pass: true,
-            namespace: asserter.namespace,
-            errors: [],
-            stats: {
-                errorsCount: 0,
-                passCount: 0,
-                rulesCount: 0
-            }
-        };
-    }
+  if (!rule) {
+    return {
+      pass: true,
+      namespace: asserter.namespace,
+      errors: [],
+      stats: {
+        errorsCount: 0,
+        passCount: 0,
+        rulesCount: 0,
+      },
+    };
+  }
 
-    const ruleResults = rule.handler(dragees).map(result => {
-        result.ruleId = rule.id;
-        return result;
+  const ruleResults = rule.handler(dragees).map((result) => {
+    result.ruleId = rule.id;
+    return result;
+  });
+
+  const rulesResultsErrors = ruleResults
+    .filter((result): result is FailedRuleResult => !result.pass)
+    .map((result) => {
+      result.error.ruleId = result.ruleId;
+      return result.error;
     });
 
-    const rulesResultsErrors = ruleResults
-        .filter((result): result is FailedRuleResult => !result.pass)
-        .map(result => {
-            result.error.ruleId = result.ruleId;
-            return result.error;
-        });
+  const rulesResultsPassed = ruleResults.filter(
+    (result): result is SuccessfulRuleResult => result.pass,
+  );
 
-    const rulesResultsPassed = ruleResults.filter(
-        (result): result is SuccessfulRuleResult => result.pass
-    );
-
-    return {
-        pass: rulesResultsErrors.length === 0,
-        namespace: asserter.namespace,
-        errors: rulesResultsErrors,
-        stats: {
-            errorsCount: rulesResultsErrors.length,
-            passCount: rulesResultsPassed.length,
-            rulesCount: asserter.rules.length
-        }
-    };
+  return {
+    pass: rulesResultsErrors.length === 0,
+    namespace: asserter.namespace,
+    errors: rulesResultsErrors,
+    stats: {
+      errorsCount: rulesResultsErrors.length,
+      passCount: rulesResultsPassed.length,
+      rulesCount: ruleResults.length,
+    },
+  };
 }
 
 /**
  * Rule severity
  */
 export enum RuleSeverity {
-    ERROR = 'error',
-    WARN = 'warn',
-    INFO = 'info'
+  ERROR = "error",
+  WARN = "warn",
+  INFO = "info",
 }
 
 export type DeclaredRule = {
-    readonly label: string;
-    readonly severity: RuleSeverity;
-    readonly handler: (dragees: Dragee[]) => RuleResult[];
+  readonly label: string;
+  readonly severity: RuleSeverity;
+  readonly handler: (dragees: Dragee[]) => RuleResult[];
 };
 
 export type Rule = DeclaredRule & { readonly id: string };
 
 const declaredRuleToRule = (namespace: string, rule: DeclaredRule): Rule => {
-    return { id: generateId(namespace, rule.label), ...rule };
+  return { id: generateId(namespace, rule.label), ...rule };
 };
 
 /**
@@ -227,10 +240,10 @@ const declaredRuleToRule = (namespace: string, rule: DeclaredRule): Rule => {
  * @returns RuleResult success/fail
  */
 export const expectDragee = (
-    root: Dragee,
-    dragee: Dragee,
-    errorMsg: string,
-    evalFn: (dragee: Dragee) => boolean
+  root: Dragee,
+  dragee: Dragee,
+  errorMsg: string,
+  evalFn: (dragee: Dragee) => boolean,
 ): RuleResult => (evalFn(dragee) ? successful() : failed(root, errorMsg));
 
 /**
@@ -242,10 +255,10 @@ export const expectDragee = (
  * @returns RuleResult success/fail
  */
 export const expectDragees = (
-    root: Dragee,
-    dependancies: Dragee[],
-    errorMsg: string,
-    evalFn: (dragees: Dragee[]) => boolean
+  root: Dragee,
+  dependancies: Dragee[],
+  errorMsg: string,
+  evalFn: (dragees: Dragee[]) => boolean,
 ): RuleResult => (evalFn(dependancies) ? successful() : failed(root, errorMsg));
 
 /**
@@ -257,8 +270,9 @@ export const expectDragees = (
  * @returns RuleResult success/fail
  */
 export const multipleExpectDragees = (
-    root: Dragee,
-    dragees: Dragee[],
-    errorMsg: string,
-    evalFn: (dragee: Dragee) => boolean
-): RuleResult[] => dragees.map(d => (evalFn(d) ? successful() : failed(root, errorMsg)));
+  root: Dragee,
+  dragees: Dragee[],
+  errorMsg: string,
+  evalFn: (dragee: Dragee) => boolean,
+): RuleResult[] =>
+  dragees.map((d) => (evalFn(d) ? successful() : failed(root, errorMsg)));


### PR DESCRIPTION
This pull request refactors the `src/asserter/index.ts` file for improved code consistency, readability, and correctness. The main changes include standardizing formatting and indentation, updating error and pass counting logic for reports, and applying consistent arrow function usage throughout the file.

**Code formatting and consistency:**

* Standardized all string quotes to double quotes and normalized indentation and comma usage for better readability and consistency. [[1]](diffhunk://#diff-7ea1ac72eb2d3df7242092ac5effc10544023cd91c6bd8339e5369a2af9f7a7fL1-R3) [[2]](diffhunk://#diff-7ea1ac72eb2d3df7242092ac5effc10544023cd91c6bd8339e5369a2af9f7a7fL70-R75) [[3]](diffhunk://#diff-7ea1ac72eb2d3df7242092ac5effc10544023cd91c6bd8339e5369a2af9f7a7fL233-R246) [[4]](diffhunk://#diff-7ea1ac72eb2d3df7242092ac5effc10544023cd91c6bd8339e5369a2af9f7a7fL248-R261) [[5]](diffhunk://#diff-7ea1ac72eb2d3df7242092ac5effc10544023cd91c6bd8339e5369a2af9f7a7fL263-R278)

**Arrow function and parameter formatting:**

* Updated all arrow functions to use parentheses around parameters and consistent formatting, improving maintainability and clarity. [[1]](diffhunk://#diff-7ea1ac72eb2d3df7242092ac5effc10544023cd91c6bd8339e5369a2af9f7a7fL58-R60) [[2]](diffhunk://#diff-7ea1ac72eb2d3df7242092ac5effc10544023cd91c6bd8339e5369a2af9f7a7fL88-R102) [[3]](diffhunk://#diff-7ea1ac72eb2d3df7242092ac5effc10544023cd91c6bd8339e5369a2af9f7a7fL119-R144) [[4]](diffhunk://#diff-7ea1ac72eb2d3df7242092ac5effc10544023cd91c6bd8339e5369a2af9f7a7fL167-R198) [[5]](diffhunk://#diff-7ea1ac72eb2d3df7242092ac5effc10544023cd91c6bd8339e5369a2af9f7a7fL263-R278)

**Report statistics calculation:**

* Changed `rulesCount` in report statistics to count the number of rule results instead of the number of rules, ensuring more accurate reporting. [[1]](diffhunk://#diff-7ea1ac72eb2d3df7242092ac5effc10544023cd91c6bd8339e5369a2af9f7a7fL145-R155) [[2]](diffhunk://#diff-7ea1ac72eb2d3df7242092ac5effc10544023cd91c6bd8339e5369a2af9f7a7fL195-R219)

**Function signature improvements:**

* Reformatted multi-argument function signatures for better readability, especially for `findRule` and `generateReportForRule`. [[1]](diffhunk://#diff-7ea1ac72eb2d3df7242092ac5effc10544023cd91c6bd8339e5369a2af9f7a7fL88-R102) [[2]](diffhunk://#diff-7ea1ac72eb2d3df7242092ac5effc10544023cd91c6bd8339e5369a2af9f7a7fL156-R169)

**Enum and type consistency:**

* Standardized the `RuleSeverity` enum and related type definitions to use double quotes and consistent formatting.

These changes collectively enhance the codebase's readability, maintainability, and correctness.